### PR TITLE
Update README for nginx and new ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Containerized HuggingFace Inference Demo
 
-This repository provides a small FastAPI service that exposes HuggingFace model inference through a Dockerized application. It includes a Prometheus sidecar for metrics collection and a helper script to launch both the inference API and the Prometheus server.
+This repository provides a small FastAPI service that exposes HuggingFace model
+inference through a Dockerized application. Requests are served via an Nginx
+front end which proxies calls under the `/api` path to the FastAPI application
+and serves a basic HTML/JS playground from the root path. It also includes a
+Prometheus sidecar for metrics collection and a helper script to launch both the
+inference API and the Prometheus server.
 
 ## Overview
 - **Language**: Python 3.9
@@ -14,12 +19,12 @@ The API is defined in [`app/main.py`](app/main.py) and provides the following en
 
 | Method & Path | Description |
 | --- | --- |
-| `GET /` | Returns basic information including the active device and cache status. |
-| `POST /predict` | Performs inference given a model name, task and input payload. Supports batch inputs. |
-| `GET /healthz` | Simple liveness check returning `{"status": "ok"}`. |
-| `GET /readiness` | Ensures the default model can load; returns `{"status": "ready"}` when the service is ready. |
-| `GET /metrics` | Exposes Prometheus metrics such as `hf_requests_total`. |
-| `GET /cache_info` | Returns statistics about the internal LRU model cache. |
+| `GET /api/` | Returns basic information including the active device and cache status. |
+| `POST /api/predict` | Performs inference given a model name, task and input payload. Supports batch inputs. |
+| `GET /api/healthz` | Simple liveness check returning `{"status": "ok"}`. |
+| `GET /api/readiness` | Ensures the default model can load; returns `{"status": "ready"}` when the service is ready. |
+| `GET /api/metrics` | Exposes Prometheus metrics such as `hf_requests_total`. |
+| `GET /api/cache_info` | Returns statistics about the internal LRU model cache. |
 
 ## Building and Running with Docker
 1. **Build the image**
@@ -32,7 +37,8 @@ The API is defined in [`app/main.py`](app/main.py) and provides the following en
    ```bash
    ./run_hf_service.sh
    ```
-   The API will be available on `http://localhost:8000` and Prometheus on `http://localhost:9090`.
+   The API will be available on `http://localhost:8080/api` and Prometheus on `http://localhost:9090`.
+   A small web playground is served from `http://localhost:8080/`.
 
 ## Checking Prometheus
 - View the Prometheus container logs:
@@ -44,7 +50,7 @@ The API is defined in [`app/main.py`](app/main.py) and provides the following en
 ## Example Request
 Once the containers are running you can test the API with `curl`:
 ```bash
-curl -X POST http://localhost:8000/predict \
+curl -X POST http://localhost:8080/api/predict \
      -H 'Content-Type: application/json' \
      -d '{"model_name": "distilbert-base-uncased-finetuned-sst-2-english", "task": "sentiment-analysis", "inputs": "I love this API!"}'
 ```


### PR DESCRIPTION
## Summary
- document nginx front-end and web playground
- update API endpoint paths
- fix ports in example usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd3ca9b38832790c140824eb41e7c